### PR TITLE
support jlcon doctest

### DIFF
--- a/src/modules/DocChecks.jl
+++ b/src/modules/DocChecks.jl
@@ -107,7 +107,7 @@ function doctest(doc::Documents.Document)
 end
 
 function doctest(block::Markdown.Code, meta::Dict)
-    if block.language == "julia"
+    if block.language == "julia" || block.language == "jlcon"
         code, sandbox = block.code, Module(:Main)
         haskey(meta, :DocTestSetup) && eval(sandbox, meta[:DocTestSetup])
         ismatch(r"^julia> "m, code)   ? eval_repl(code, sandbox)   :


### PR DESCRIPTION
The syntax highlighter used in MkDocs is Pygments, which supports syntax highlighting of Julia's REPL. In order to use that, we need to name the fenced code as `jlcon` as follows:

    ```jlcon
    julia> 1 + 1
    2
    
    ```

This pull request adds `jlcon` to the list of doctest languages so that the doctest runs code in `jlcon`.