### PR TITLE
remove horizontal rule after each doc

### DIFF
--- a/src/modules/Writers.jl
+++ b/src/modules/Writers.jl
@@ -63,7 +63,6 @@ function render(io::IO, mime::MIME"text/plain", node::Expanders.DocsNode, page, 
         <a id='$(node.anchor.id)' href='#$(node.anchor.id)'>#</a>
         **`$(node.object.binding)`** &mdash; *$(Utilities.doccat(node.object))*.
 
-        ---
         """
     )
     render(io, mime, source_urls(node.docstr), page, doc)


### PR DESCRIPTION
This pull request removes horizontal rules after docstrings. I think this is semantically wrong and visually misleading.

Semantically, the horizontal rules should not be used to separate header and description because:
> In HTML5, the `<hr>` tag defines a thematic break.

<http://www.w3schools.com/tags/tag_hr.asp>


Visually, it makes hard to find a description when a series of docstrings are rendered:
![screen shot 2016-05-11 at 17 16 44](https://cloud.githubusercontent.com/assets/905683/15174393/7a4dd4ae-179c-11e6-8402-84bfd6e96515.png)