### PR TITLE
Generate stub documentation

### DIFF
--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -88,6 +88,17 @@ Formats.Format
 Formats.mimetype
 ```
 
+## Generator
+
+```@docs
+Generator
+Generator.savefile
+Generator.make
+Generator.gitignore
+Generator.mkdocs
+Generator.index
+```
+
 ## Walkers
 
 ```@docs

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -22,6 +22,7 @@ Pages = ["public.md"]
 Documenter
 makedocs
 deploydocs
+Documenter.generate
 Travis
 Travis.genkeys
 Deps

--- a/src/Documenter.jl
+++ b/src/Documenter.jl
@@ -8,6 +8,9 @@ Two functions are exported from this module for public use:
 - [`makedocs`](@ref). Generates documentation from docstrings and templated markdown files.
 - [`deploydocs`](@ref). Deploys generated documentation from *Travis-CI* to *GitHub Pages*.
 
+Additionally it provides the unexported [`Documenter.generate`](@ref), which can be used to
+generate documentation stubs for new packages.
+
 """
 module Documenter
 
@@ -29,6 +32,7 @@ submodule(:CrossReferences)
 submodule(:DocChecks)
 submodule(:Writers)
 submodule(:Deps)
+submodule(:Generator)
 
 # User Interface.
 # ---------------
@@ -439,6 +443,94 @@ function genkeys(package)
     end
 end
 
+end
+
+"""
+    generate(
+        pkgname;
+        dir = "<package directory>/docs"
+    )
+
+Creates a documentation stub for a package called `pkgname`. The location of
+the documentation is assumed to be `<package directory>/docs`, but this can
+be overriden with keyword arguments.
+
+It creates the following files
+
+    docs/
+        .gitignore
+        src/index.md
+        make.jl
+        mkdocs.yml
+
+# Positionals
+
+**`pkgname`** is the name of the package (without `.jl`). It is used to
+determine the location of the documentation if `dir` is not provided.
+
+# Keywords
+
+**`dir`** defines the directory where the documentation will be generated.
+It defaults to `<package directory>/docs`. The directory must not exist.
+
+# Examples
+
+    julia> using Documenter
+
+    julia> Documenter.generate("MyPackageName")
+    [ ... output ... ]
+
+"""
+function generate(pkgname::AbstractString; dir=nothing)
+    # TODO:
+    #   - set up deployment to `gh-pages`
+    #   - fetch url and username automatically (e.g from git remote.origin.url)
+
+    # Check the validity of the package name
+    if length(pkgname) == 0
+        error("Package name can not be an empty string.")
+    end
+    # Determine the root directory where we wish to generate the docs and
+    # check that it is a valid directory.
+    docroot = if dir === nothing
+        pkgdir = Pkg.dir(pkgname)
+        if !isdir(pkgdir)
+            error("Unable to find package $(pkgname).jl at $(pkgdir).")
+        end
+        joinpath(pkgdir, "docs")
+    else
+        dir
+    end
+
+    if ispath(docroot)
+        error("Directory $(docroot) already exists.")
+    end
+
+    # deploy the stub
+    try
+        info("Deploying documentation to $(docroot)")
+        mkdir(docroot)
+
+        # create the root doc files
+        Generator.savefile(docroot, ".gitignore") do io
+            write(io, Generator.gitignore())
+        end
+        Generator.savefile(docroot, "make.jl") do io
+            write(io, Generator.make(pkgname))
+        end
+        Generator.savefile(docroot, "mkdocs.yml") do io
+            write(io, Generator.mkdocs(pkgname))
+        end
+
+        # Create the default documentation source files
+        Generator.savefile(docroot, "src/index.md") do io
+            write(io, Generator.index(pkgname))
+        end
+    catch
+        rm(docroot, recursive=true)
+        rethrow()
+    end
+    nothing
 end
 
 end

--- a/src/modules/Generator.jl
+++ b/src/modules/Generator.jl
@@ -1,0 +1,110 @@
+"""
+Provides the functions related to generating documentation stubs.
+"""
+module Generator
+
+"""
+    savefile(f, root, filename)
+
+Attempts to save a file at `\$(root)/\$(filename)`. `f` will be called with file
+stream (see [`open`](http://docs.julialang.org/en/latest/stdlib/io-network/#Base.open)).
+
+`filename` can also be a file in a subdirectory (e.g. `src/index.md`), and then
+then subdirectories will be created automatically.
+"""
+function savefile(f, root, filename)
+    filepath = joinpath(root, filename)
+    if ispath(filepath) error("$(filepath) already exists") end
+    info("Generating $filename at $filepath")
+    mkpath(dirname(filepath))
+    open(f,filepath,"w")
+end
+
+"""
+Contents of the default `make.jl` file.
+"""
+function make(pkgname)
+    """
+    using Documenter
+    using $(pkgname)
+
+    makedocs(
+        modules = [$(pkgname)]
+    )
+
+    #deploydocs()
+    """
+end
+
+"""
+Contents of the default `.gitignore` file.
+"""
+function gitignore()
+    """
+    build/
+    site/
+    """
+end
+
+
+macro mkdocs_default(name,value,default)
+    quote
+        if $value===nothing
+            "#"*$name*$default
+        else
+            $name*$value
+        end
+    end
+end
+
+"""
+Contents of the default `mkdocs.yml` file.
+"""
+function mkdocs(pkgname;
+        description = nothing,
+        author = nothing,
+        url = nothing
+    )
+    s = """
+    # See the mkdocs user guide for more information on these settings.
+    #   http://www.mkdocs.org/user-guide/configuration/
+
+    site_name:        $(pkgname).jl
+    $(@mkdocs_default "repo_url:         " url "https://github.com/USER_NAME/PACKAGE_NAME.jl")
+    $(@mkdocs_default "site_description: " description "Description...")
+    $(@mkdocs_default "site_author:      " author "USER_NAME")
+
+    theme: readthedocs
+
+    extra_css:
+      - assets/Documenter.css
+
+    extra_javascript:
+      - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
+      - assets/mathjaxhelper.js
+
+    markdown_extensions:
+      - extra
+      - tables
+      - fenced_code
+      - mdx_math
+
+    docs_dir: 'build'
+
+    pages:
+      - Home: index.md
+    """
+end
+
+"""
+Contents of the default `src/index.md` file.
+"""
+function index(pkgname)
+    """
+    # $(pkgname).jl
+
+    Documentation for $(pkgname).jl
+    """
+end
+
+end

--- a/src/modules/Generator.jl
+++ b/src/modules/Generator.jl
@@ -32,7 +32,12 @@ function make(pkgname)
         modules = [$(pkgname)]
     )
 
-    #deploydocs()
+    # Documenter can also automatically deploy documentation to gh-pages.
+    # See "Hosting Documentation" and deploydocs() in the Documenter manual
+    # for more information.
+    #=deploydocs(
+        repo = "<repository url>"
+    )=#
     """
 end
 


### PR DESCRIPTION
Addresses #57.

Needs more polish before it can be merged, but thoughts on the exact API would be welcome. Right now I propose a very simple `Documenter.generate(pkgname)`.

Also, no format argument at the moment, just defaulting to mkdocs.