### PR TITLE
Filtering and sorting for `index` blocks

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -44,6 +44,23 @@ Depth = 2
 
 ## [Index](@id main-index)
 
+### Modules
+
 ```@index
 Pages = ["lib/public.md", "lib/internals.md"]
+Order = [:module]
+```
+
+### Functions
+
+```@index
+Pages = ["lib/public.md", "lib/internals.md"]
+Order = [:function]
+```
+
+### Types
+
+```@index
+Pages = ["lib/public.md", "lib/internals.md"]
+Order = [:type]
 ```

--- a/docs/src/man/syntax.md
+++ b/docs/src/man/syntax.md
@@ -149,19 +149,29 @@ See [Setup Code](@ref) section of the Doctests page for an explanation of `DocTe
 
 ## `@index` block
 
-Generates a list of links to docstrings that have been spliced into a document. The only
-valid setting is currently `Pages = ...`.
+Generates a list of links to docstrings that have been spliced into a document. Valid
+settings are `Pages`, `Modules`, and `Order`. For example:
 
 ````markdown
 ```@index
-Pages = ["foo.md"]
+Pages   = ["foo.md"]
+Modules = [Foo, Bar]
+Order   = [:function, :type]
 ```
 ````
 
-When `Pages` is not provided all pages in the document are included.
+When `Pages` or `Modules` are not provided then all pages or modules are included. `Order`
+defaults to
 
-Note that the `Pages` value can be any valid Julia code and so can be something more complex
-that an array literal if a large number of pages must be included, i.e.
+```
+[:module, :constant, :type, :function, :macro]
+```
+
+if not specified. `Order` and `Modules` behave the same way as in [`@autodocs` block](@ref)s
+and filter out docstrings that do not match one of the modules or categories specified.
+
+Note that the values assigned to `Pages`, `Modules`, and `Order` may be any valid Julia code
+and thus can be something more complex that an array literal if required, i.e.
 
 ````markdown
 ```@index
@@ -170,7 +180,7 @@ Pages = map(file -> joinpath("man", file), readdir("man"))
 ````
 
 It should be noted though that in this case `Pages` may not be sorted in the order that is
-expected by the user. Try to stick to array literals for `Pages` as much as possible.
+expected by the user. Try to stick to array literals as much as possible.
 
 ## `@contents` block
 

--- a/src/modules/CrossReferences.jl
+++ b/src/modules/CrossReferences.jl
@@ -63,9 +63,9 @@ end
 xref(other, meta, page, doc) = true # Continue to `walk` through element `other`.
 
 function basicxref(link::Markdown.Link, meta, page, doc)
-    if isa(link.text[1], Base.Markdown.Code)
+    if length(link.text) === 1 && isa(link.text[1], Base.Markdown.Code)
         docsxref(link, meta, page, doc)
-    elseif isa(link.text, Vector) && length(link.text) === 1
+    elseif isa(link.text, Vector)
         # No `name` was provided, since given a `@ref`, so slugify the `.text` instead.
         text = strip(sprint(Markdown.plain, Markdown.Paragraph(link.text)))
         if ismatch(r"#[0-9]+", text)


### PR DESCRIPTION
Fixes #64.

Providing `Modules = [...]` or `[Order = [...]` now work in a similar way to `autodoc` blocks to allow for more fine-grained control of the content shown in index pages.

The exact ordering of the resulting indexes is up for discussion. Currently it's based on the page, module, category, and then name of binding. Is that a suitable order? Suggestions welcome.